### PR TITLE
Add DMAC register details

### DIFF
--- a/allwinner-hal/src/dma.rs
+++ b/allwinner-hal/src/dma.rs
@@ -1,0 +1,1 @@
+mod register;

--- a/allwinner-hal/src/dma/register.rs
+++ b/allwinner-hal/src/dma/register.rs
@@ -1,0 +1,227 @@
+use volatile_register::{RO, RW};
+
+/// 直接内存访问控制器（DMAC）通道寄存器
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct ChannelRegisterBlock {
+    /// DMAC 通道使能寄存器
+    pub enable: ChannelEnable,
+    /// DMAC 通道暂停寄存器
+    pub pause: ChannelPause,
+    /// DMAC 通道起始地址寄存器
+    pub start_addr: ChannelStartAddr,
+    /// DMAC 通道配置寄存器
+    pub config: ChannelConfig,
+    /// DMAC 通道当前源地址寄存器
+    pub current_src_addr: ChannelCurrentSrcAddr,
+    /// DMAC 通道当前目标地址寄存器
+    pub current_destination: ChannelCurrentDestAddr,
+    /// DMAC 通道剩余字节计数寄存器
+    pub byte_counter_left: ChannelByteCounterLeft,
+    /// DMAC 通道参数寄存器
+    pub parameter: ChannelParameter,
+    _reserved0: [u8; 0x8],
+    /// DMAC 模式寄存器
+    pub mode: ChannelMode,
+    /// DMAC 前描述符地址寄存器
+    pub former_desc_addr: ChannelFormerDescAddr,
+    /// DMAC 包数量寄存器
+    pub package_num: ChannelPackageNum,
+    _reserved1: [u8; 0xC],
+}
+
+/// DMAC 通道使能寄存器
+#[repr(C)]
+pub struct ChannelEnable {
+    pub dma_en: RW<u32>, // DMA使能位
+}
+
+impl ChannelEnable {
+    // 获取 `dma_en` 位的值
+    #[inline]
+    pub fn dma_en(&self) -> bool {
+        (self.dma_en.read() & 0x01) != 0
+    }
+
+    // 设置 `dma_en` 位的值
+    #[inline]
+    pub fn set_dma_en(&mut self, value: bool) {
+        let mut reg = self.dma_en.read();
+        if value {
+            reg |= 0x01;  // 设置使能位
+        } else {
+            reg &= !0x01; // 清除使能位
+        }
+        self.dma_en.write(reg);
+    }
+}
+
+/// DMAC 通道暂停寄存器
+#[repr(C)]
+pub struct ChannelPause {
+    pub dma_pause: RW<u32>, // DMA暂停位
+}
+
+impl ChannelPause {
+    // 获取 `dma_pause` 位的值
+    #[inline]
+    pub fn dma_pause(&self) -> bool {
+        (self.dma_pause.read() & 0x01) != 0
+    }
+
+    // 设置 `dma_pause` 位的值
+    #[inline]
+    pub fn set_dma_pause(&mut self, value: bool) {
+        let mut reg = self.dma_pause.read();
+        if value {
+            reg |= 0x01;  // 设置暂停位
+        } else {
+            reg &= !0x01; // 清除暂停位
+        }
+        self.dma_pause.write(reg);
+    }
+}
+
+/// DMAC 通道起始地址寄存器
+#[repr(C)]
+pub struct ChannelStartAddr {
+    pub dma_desc_addr: RW<u32>, // DMA描述符地址
+}
+
+impl ChannelStartAddr {
+    // 设置描述符地址
+    #[inline]
+    pub fn set_desc_addr(&mut self, addr: u32) {
+        self.dma_desc_addr.write(addr);
+    }
+}
+
+/// DMAC 通道配置寄存器
+#[repr(C)]
+pub struct ChannelConfig {
+    pub bmode_sel: RW<u32>, // 块模式选择位
+    pub dma_dest_data_width: RW<u32>, // 目标数据宽度
+    pub dma_addr_mode: RW<u32>, // 地址模式
+    pub dma_src_data_width: RW<u32>, // 源数据宽度
+    pub dma_src_addr_mode: RW<u32>, // 源地址模式
+}
+
+impl ChannelConfig {
+    // 获取源数据宽度
+    #[inline]
+    pub fn dma_src_data_width(&self) -> u32 {
+        self.dma_src_data_width.read()
+    }
+
+    // 设置源数据宽度
+    #[inline]
+    pub fn set_dma_src_data_width(&mut self, width: u32) {
+        self.dma_src_data_width.write(width);
+    }
+}
+
+/// DMAC 通道当前源地址寄存器
+#[repr(C)]
+pub struct ChannelCurrentSrcAddr {
+    pub dma_cur_src: RO<u32>, // 当前源地址
+}
+
+impl ChannelCurrentSrcAddr {
+    // 获取当前源地址
+    #[inline]
+    pub fn dma_cur_src(&self) -> u32 {
+        self.dma_cur_src.read()
+    }
+}
+
+/// DMAC 通道当前目标地址寄存器
+#[repr(C)]
+pub struct ChannelCurrentDestAddr {
+    pub dma_cur_dest: RO<u32>, // 当前目标地址
+}
+
+impl ChannelCurrentDestAddr {
+    // 获取当前目标地址
+    #[inline]
+    pub fn dma_cur_dest(&self) -> u32 {
+        self.dma_cur_dest.read()
+    }
+}
+
+/// DMAC 通道剩余字节计数寄存器
+#[repr(C)]
+pub struct ChannelByteCounterLeft {
+    pub dma_bcnt_left: RO<u32>, // 剩余字节计数
+}
+
+impl ChannelByteCounterLeft {
+    // 获取剩余字节计数
+    #[inline]
+    pub fn dma_bcnt_left(&self) -> u32 {
+        self.dma_bcnt_left.read()
+    }
+}
+
+/// DMAC 通道参数寄存器
+#[repr(C)]
+pub struct ChannelParameter {
+    pub wait_cycles: RW<u32>, // 等待时钟周期数
+}
+
+impl ChannelParameter {
+    // 设置等待时钟周期
+    #[inline]
+    pub fn set_wait_cycles(&mut self, cycles: u32) {
+        self.wait_cycles.write(cycles);
+    }
+}
+
+/// DMAC 模式寄存器
+#[repr(C)]
+pub struct ChannelMode {
+    pub dma_src_mode: RW<u32>, // 源通信模式
+    pub dma_dst_mode: RW<u32>, // 目标通信模式
+}
+
+impl ChannelMode {
+    // 获取源通信模式
+    #[inline]
+    pub fn dma_src_mode(&self) -> u32 {
+        self.dma_src_mode.read()
+    }
+
+    // 设置源通信模式
+    #[inline]
+    pub fn set_dma_src_mode(&mut self, mode: u32) {
+        self.dma_src_mode.write(mode);
+    }
+}
+
+/// DMAC 前描述符地址寄存器
+#[repr(C)]
+pub struct ChannelFormerDescAddr {
+    pub dma_fdesc_addr: RO<u32>, // 前描述符地址
+}
+
+impl ChannelFormerDescAddr {
+    // 获取前描述符地址
+    #[inline]
+    pub fn dma_fdesc_addr(&self) -> u32 {
+        self.dma_fdesc_addr.read()
+    }
+}
+
+/// DMAC 包数量寄存器
+#[repr(C)]
+pub struct ChannelPackageNum {
+    pub dma_pkg_num: RO<u32>, // 包数量
+}
+
+impl ChannelPackageNum {
+    // 获取包数量
+    #[inline]
+    pub fn dma_pkg_num(&self) -> u32 {
+        self.dma_pkg_num.read()
+    }
+}
+

--- a/allwinner-hal/src/dma/register.rs
+++ b/allwinner-hal/src/dma/register.rs
@@ -1,227 +1,434 @@
 use volatile_register::{RO, RW};
 
-/// 直接内存访问控制器（DMAC）通道寄存器
+/// Direct Memory Access Controller registers.
 #[repr(C)]
-#[derive(Debug, Default)]
-pub struct ChannelRegisterBlock {
-    /// DMAC 通道使能寄存器
-    pub enable: ChannelEnable,
-    /// DMAC 通道暂停寄存器
-    pub pause: ChannelPause,
-    /// DMAC 通道起始地址寄存器
-    pub start_addr: ChannelStartAddr,
-    /// DMAC 通道配置寄存器
-    pub config: ChannelConfig,
-    /// DMAC 通道当前源地址寄存器
-    pub current_src_addr: ChannelCurrentSrcAddr,
-    /// DMAC 通道当前目标地址寄存器
-    pub current_destination: ChannelCurrentDestAddr,
-    /// DMAC 通道剩余字节计数寄存器
-    pub byte_counter_left: ChannelByteCounterLeft,
-    /// DMAC 通道参数寄存器
-    pub parameter: ChannelParameter,
+pub struct RegisterBlock {
+    /// DMAC IRQ Enable Register 0.
+    pub irq_enable0: RW<u32>,
+    /// DMAC IRQ Enable Register 1.
+    pub irq_enable1: RW<u32>,
     _reserved0: [u8; 0x8],
-    /// DMAC 模式寄存器
-    pub mode: ChannelMode,
-    /// DMAC 前描述符地址寄存器
-    pub former_desc_addr: ChannelFormerDescAddr,
-    /// DMAC 包数量寄存器
-    pub package_num: ChannelPackageNum,
+    /// DMAC IRQ Pending Register 0.
+    pub irq_pending0: RW<u32>,
+    /// DMAC IRQ Pending Register 1.
+    pub irq_pending1: RW<u32>,
+    _reserved1: [u8; 0x10],
+    /// DMAC Auto Gating Register.
+    pub auto_gating: RW<u32>,
+    _reserved2: [u8; 0x4],
+    /// DMAC Status Register.
+    pub status: RO<u32>,
+    _reserved3: [u8; 0xCC],
+    /// DMAC Channels' Registers.
+    pub channels: [ChannelRegisterBlock; 16],
+}
+
+/// DMAC channel registers.
+#[repr(C)]
+pub struct ChannelRegisterBlock {
+    /// DMAC Channel Enable Register.
+    pub enable: RW<u32>,
+    /// DMAC Channel Pause Register.
+    pub pause: RW<u32>,
+    /// DMAC Channel Start Address Register.
+    pub start_addr: RW<u32>,
+    /// DMAC Channel Configuration Register.
+    pub config: RO<u32>,
+    /// DMAC Channel Current Source Register.
+    pub current_src_addr: RO<u32>,
+    /// DMAC Channel Current Destination Register.
+    pub current_destination: RO<u32>,
+    /// DMAC Channel Byte Counter Left Register.
+    pub byte_counter_left: RO<u32>,
+    /// DMAC Channel Parameter Register.
+    pub parameter: RO<u32>,
+    _reserved0: [u8; 0x8],
+    /// DMAC Mode Register.
+    pub mode: RW<u32>,
+    /// DMAC Former Descriptor Address Register.
+    pub former_desc_addr: RO<u32>,
+    /// DMAC Package Number Register.
+    pub package_num: RO<u32>,
     _reserved1: [u8; 0xC],
 }
 
-/// DMAC 通道使能寄存器
-#[repr(C)]
-pub struct ChannelEnable {
-    pub dma_en: RW<u32>, // DMA使能位
-}
+impl ChannelEnableRegister {
+    // DMA Channel Enable (Bit 0)
+    pub const DMA_EN: u32 = 0x1 << 0;
 
-impl ChannelEnable {
-    // 获取 `dma_en` 位的值
+    /// Raw register value for DMA Channel Enable Register.
     #[inline]
-    pub fn dma_en(&self) -> bool {
-        (self.dma_en.read() & 0x01) != 0
+    pub const fn raw(self) -> u32 {
+        self.0
     }
 
-    // 设置 `dma_en` 位的值
+    /// Create from raw register value.
     #[inline]
-    pub fn set_dma_en(&mut self, value: bool) {
-        let mut reg = self.dma_en.read();
-        if value {
-            reg |= 0x01;  // 设置使能位
-        } else {
-            reg &= !0x01; // 清除使能位
-        }
-        self.dma_en.write(reg);
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the DMA channel enable bit.
+    #[inline]
+    pub const fn dma_en(self) -> u32 {
+        (self.0 & Self::DMA_EN) >> 0
     }
 }
 
-/// DMAC 通道暂停寄存器
-#[repr(C)]
-pub struct ChannelPause {
-    pub dma_pause: RW<u32>, // DMA暂停位
-}
+impl ChannelPauseRegister {
+    // DMA Pause bit (Bit 0)
+    pub const DMA_PAUSE: u32 = 0x1 << 0;
 
-impl ChannelPause {
-    // 获取 `dma_pause` 位的值
+    /// Raw register value for DMA Channel Pause Register.
     #[inline]
-    pub fn dma_pause(&self) -> bool {
-        (self.dma_pause.read() & 0x01) != 0
+    pub const fn raw(self) -> u32 {
+        self.0
     }
 
-    // 设置 `dma_pause` 位的值
+    /// Create from raw register value.
     #[inline]
-    pub fn set_dma_pause(&mut self, value: bool) {
-        let mut reg = self.dma_pause.read();
-        if value {
-            reg |= 0x01;  // 设置暂停位
-        } else {
-            reg &= !0x01; // 清除暂停位
-        }
-        self.dma_pause.write(reg);
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Check if DMA transfer is paused.
+    #[inline]
+    pub const fn dma_pause(self) -> u32 {
+        (self.0 & Self::DMA_PAUSE) >> 0
     }
 }
 
-/// DMAC 通道起始地址寄存器
-#[repr(C)]
-pub struct ChannelStartAddr {
-    pub dma_desc_addr: RW<u32>, // DMA描述符地址
-}
+impl ChannelStartAddrRegister {
+    // DMA descriptor address lower 30 bits (Bits [31:2])
+    pub const DMA_DESC_ADDR: u32 = 0x3FFFFFFF << 2;
 
-impl ChannelStartAddr {
-    // 设置描述符地址
+    // DMA descriptor address higher 2 bits (Bits [1:0])
+    pub const DMA_DESC_HIGH_ADDR: u32 = 0x3 << 0;
+
+    /// Raw register value for DMA Channel Start Address Register.
     #[inline]
-    pub fn set_desc_addr(&mut self, addr: u32) {
-        self.dma_desc_addr.write(addr);
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get lower 30 bits of the DMA descriptor address.
+    #[inline]
+    pub const fn dma_desc_addr(self) -> u32 {
+        (self.0 & Self::DMA_DESC_ADDR) >> 2
+    }
+
+    /// Get higher 2 bits of the DMA descriptor address.
+    #[inline]
+    pub const fn dma_desc_high_addr(self) -> u32 {
+        (self.0 & Self::DMA_DESC_HIGH_ADDR) >> 0
+    }
+
+    /// Get full 32-bit DMA descriptor address with alignment.
+    #[inline]
+    pub const fn full_dma_desc_addr(self) -> u32 {
+        (self.dma_desc_high_addr() << 30) | (self.dma_desc_addr() << 2)
     }
 }
 
-/// DMAC 通道配置寄存器
-#[repr(C)]
-pub struct ChannelConfig {
-    pub bmode_sel: RW<u32>, // 块模式选择位
-    pub dma_dest_data_width: RW<u32>, // 目标数据宽度
-    pub dma_addr_mode: RW<u32>, // 地址模式
-    pub dma_src_data_width: RW<u32>, // 源数据宽度
-    pub dma_src_addr_mode: RW<u32>, // 源地址模式
-}
+impl ChannelConfigRegister {
+    // BMODE_SEL (Bit 30)
+    pub const BMODE_SEL: u32 = 0x1 << 30;
 
-impl ChannelConfig {
-    // 获取源数据宽度
+    // DMA_DEST_DATA_WIDTH (Bits [29:27])
+    pub const DMA_DEST_DATA_WIDTH: u32 = 0x7 << 27;
+
+    // DMA_DEST_BLOCK_SIZE (Bits [26:25])
+    pub const DMA_DEST_BLOCK_SIZE: u32 = 0x3 << 25;
+
+    // DMA_ADDR_MODE (Bit 24)
+    pub const DMA_ADDR_MODE: u32 = 0x1 << 24;
+
+    // DMA_DEST_DRQ_TYPE (Bits [23:16])
+    pub const DMA_DEST_DRQ_TYPE: u32 = 0xFF << 16;
+
+    // DMA_SRC_DATA_WIDTH (Bits [15:11])
+    pub const DMA_SRC_DATA_WIDTH: u32 = 0xF << 11;
+
+    // DMA_SRC_ADDR_MODE (Bit 8)
+    pub const DMA_SRC_ADDR_MODE: u32 = 0x1 << 8;
+
+    // DMA_SRC_BLOCK_SIZE (Bits [7:6])
+    pub const DMA_SRC_BLOCK_SIZE: u32 = 0x3 << 6;
+
+    // DMA_SRC_DRQ_TYPE (Bits [5:0])
+    pub const DMA_SRC_DRQ_TYPE: u32 = 0x3F << 0;
+
+    /// Raw register value for DMA Channel Configuration Register.
     #[inline]
-    pub fn dma_src_data_width(&self) -> u32 {
-        self.dma_src_data_width.read()
+    pub const fn raw(self) -> u32 {
+        self.0
     }
 
-    // 设置源数据宽度
+    /// Create from raw register value.
     #[inline]
-    pub fn set_dma_src_data_width(&mut self, width: u32) {
-        self.dma_src_data_width.write(width);
-    }
-}
-
-/// DMAC 通道当前源地址寄存器
-#[repr(C)]
-pub struct ChannelCurrentSrcAddr {
-    pub dma_cur_src: RO<u32>, // 当前源地址
-}
-
-impl ChannelCurrentSrcAddr {
-    // 获取当前源地址
-    #[inline]
-    pub fn dma_cur_src(&self) -> u32 {
-        self.dma_cur_src.read()
-    }
-}
-
-/// DMAC 通道当前目标地址寄存器
-#[repr(C)]
-pub struct ChannelCurrentDestAddr {
-    pub dma_cur_dest: RO<u32>, // 当前目标地址
-}
-
-impl ChannelCurrentDestAddr {
-    // 获取当前目标地址
-    #[inline]
-    pub fn dma_cur_dest(&self) -> u32 {
-        self.dma_cur_dest.read()
-    }
-}
-
-/// DMAC 通道剩余字节计数寄存器
-#[repr(C)]
-pub struct ChannelByteCounterLeft {
-    pub dma_bcnt_left: RO<u32>, // 剩余字节计数
-}
-
-impl ChannelByteCounterLeft {
-    // 获取剩余字节计数
-    #[inline]
-    pub fn dma_bcnt_left(&self) -> u32 {
-        self.dma_bcnt_left.read()
-    }
-}
-
-/// DMAC 通道参数寄存器
-#[repr(C)]
-pub struct ChannelParameter {
-    pub wait_cycles: RW<u32>, // 等待时钟周期数
-}
-
-impl ChannelParameter {
-    // 设置等待时钟周期
-    #[inline]
-    pub fn set_wait_cycles(&mut self, cycles: u32) {
-        self.wait_cycles.write(cycles);
-    }
-}
-
-/// DMAC 模式寄存器
-#[repr(C)]
-pub struct ChannelMode {
-    pub dma_src_mode: RW<u32>, // 源通信模式
-    pub dma_dst_mode: RW<u32>, // 目标通信模式
-}
-
-impl ChannelMode {
-    // 获取源通信模式
-    #[inline]
-    pub fn dma_src_mode(&self) -> u32 {
-        self.dma_src_mode.read()
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
     }
 
-    // 设置源通信模式
+    /// Get the BMODE_SEL bit.
     #[inline]
-    pub fn set_dma_src_mode(&mut self, mode: u32) {
-        self.dma_src_mode.write(mode);
+    pub const fn bmode_sel(self) -> u32 {
+        (self.0 & Self::BMODE_SEL) >> 30
+    }
+
+    /// Get the DMA_DEST_DATA_WIDTH bits.
+    #[inline]
+    pub const fn dma_dest_data_width(self) -> u32 {
+        (self.0 & Self::DMA_DEST_DATA_WIDTH) >> 27
+    }
+
+    /// Get the DMA_DEST_BLOCK_SIZE bits.
+    #[inline]
+    pub const fn dma_dest_block_size(self) -> u32 {
+        (self.0 & Self::DMA_DEST_BLOCK_SIZE) >> 25
+    }
+
+    /// Get the DMA_ADDR_MODE bit.
+    #[inline]
+    pub const fn dma_addr_mode(self) -> u32 {
+        (self.0 & Self::DMA_ADDR_MODE) >> 24
+    }
+
+    /// Get the DMA_DEST_DRQ_TYPE bits.
+    #[inline]
+    pub const fn dma_dest_drq_type(self) -> u32 {
+        (self.0 & Self::DMA_DEST_DRQ_TYPE) >> 16
+    }
+
+    /// Get the DMA_SRC_DATA_WIDTH bits.
+    #[inline]
+    pub const fn dma_src_data_width(self) -> u32 {
+        (self.0 & Self::DMA_SRC_DATA_WIDTH) >> 11
+    }
+
+    /// Get the DMA_SRC_ADDR_MODE bit.
+    #[inline]
+    pub const fn dma_src_addr_mode(self) -> u32 {
+        (self.0 & Self::DMA_SRC_ADDR_MODE) >> 8
+    }
+
+    /// Get the DMA_SRC_BLOCK_SIZE bits.
+    #[inline]
+    pub const fn dma_src_block_size(self) -> u32 {
+        (self.0 & Self::DMA_SRC_BLOCK_SIZE) >> 6
+    }
+
+    /// Get the DMA_SRC_DRQ_TYPE bits.
+    #[inline]
+    pub const fn dma_src_drq_type(self) -> u32 {
+        (self.0 & Self::DMA_SRC_DRQ_TYPE) >> 0
     }
 }
 
-/// DMAC 前描述符地址寄存器
-#[repr(C)]
-pub struct ChannelFormerDescAddr {
-    pub dma_fdesc_addr: RO<u32>, // 前描述符地址
-}
+impl ChannelCurrentSrcAddrRegister {
+    // DMA Current Source Address (Bits [31:0])
+    pub const DMA_CUR_SRC: u32 = 0xFFFFFFFF;
 
-impl ChannelFormerDescAddr {
-    // 获取前描述符地址
+    /// Raw register value for DMA Channel Current Source Address Register.
     #[inline]
-    pub fn dma_fdesc_addr(&self) -> u32 {
-        self.dma_fdesc_addr.read()
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the DMA current source address.
+    #[inline]
+    pub const fn dma_cur_src(self) -> u32 {
+        self.0 & Self::DMA_CUR_SRC
     }
 }
 
-/// DMAC 包数量寄存器
-#[repr(C)]
-pub struct ChannelPackageNum {
-    pub dma_pkg_num: RO<u32>, // 包数量
-}
+impl ChannelCurrentDestAddrRegister {
+    // DMA Current Destination Address (Bits [31:0])
+    pub const DMA_CUR_DEST: u32 = 0xFFFFFFFF;
 
-impl ChannelPackageNum {
-    // 获取包数量
+    /// Raw register value for DMA Channel Current Destination Address Register.
     #[inline]
-    pub fn dma_pkg_num(&self) -> u32 {
-        self.dma_pkg_num.read()
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the DMA current destination address.
+    #[inline]
+    pub const fn dma_cur_dest(self) -> u32 {
+        self.0 & Self::DMA_CUR_DEST
     }
 }
 
+impl ChannelByteCounterLeftRegister {
+    // DMA Byte Counter Left (Bits [24:0])
+    pub const DMA_BCNT_LEFT: u32 = 0xFFFFFF;
+
+    /// Raw register value for DMA Channel Byte Counter Left Register.
+    #[inline]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the DMA byte counter left value.
+    #[inline]
+    pub const fn dma_bcnt_left(self) -> u32 {
+        self.0 & Self::DMA_BCNT_LEFT
+    }
+}
+
+impl ChannelParameterRegister {
+    // WAIT_CYC (Bits [7:0])
+    pub const WAIT_CYC: u32 = 0xFF << 0;
+
+    /// Raw register value for DMA Channel Parameter Register.
+    #[inline]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the WAIT_CYC value.
+    #[inline]
+    pub const fn wait_cyc(self) -> u32 {
+        self.0 & Self::WAIT_CYC
+    }
+}
+
+impl ChannelModeRegister {
+    // DMA_DST_MODE (Bit 3)
+    pub const DMA_DST_MODE: u32 = 0x1 << 3;
+
+    // DMA_SRC_MODE (Bit 2)
+    pub const DMA_SRC_MODE: u32 = 0x1 << 2;
+
+    /// Raw register value for DMA Channel Mode Register.
+    #[inline]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the DMA destination communication mode.
+    #[inline]
+    pub const fn dma_dst_mode(self) -> u32 {
+        (self.0 & Self::DMA_DST_MODE) >> 3
+    }
+
+    /// Get the DMA source communication mode.
+    #[inline]
+    pub const fn dma_src_mode(self) -> u32 {
+        (self.0 & Self::DMA_SRC_MODE) >> 2
+    }
+}
+
+impl ChannelFormerDescAddrRegister {
+    // DMA Former Descriptor Address (Bits [31:0])
+    pub const DMA_FDESC_ADDR: u32 = 0xFFFFFFFF;
+
+    /// Raw register value for DMA Channel Former Descriptor Address Register.
+    #[inline]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the DMA former descriptor address.
+    #[inline]
+    pub const fn dma_fdesc_addr(self) -> u32 {
+        self.0 & Self::DMA_FDESC_ADDR
+    }
+}
+
+impl ChannelPackageNumRegister {
+    // DMA Package Number (Bits [31:0])
+    pub const DMA_PKG_NUM: u32 = 0xFFFFFFFF;
+
+    /// Raw register value for DMA Channel Package Number Register.
+    #[inline]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Create from raw register value.
+    #[inline]
+    pub const fn from_raw(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the DMA package number.
+    #[inline]
+    pub const fn dma_pkg_num(self) -> u32 {
+        self.0 & Self::DMA_PKG_NUM
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ChannelRegisterBlock, RegisterBlock};
+    use core::mem::{offset_of, size_of};
+    #[test]
+    fn offset_registerblock() {
+        assert_eq!(offset_of!(RegisterBlock, irq_enable0), 0x0);
+        assert_eq!(offset_of!(RegisterBlock, irq_enable1), 0x4);
+        assert_eq!(offset_of!(RegisterBlock, irq_pending0), 0x10);
+        assert_eq!(offset_of!(RegisterBlock, irq_pending1), 0x14);
+        assert_eq!(offset_of!(RegisterBlock, auto_gating), 0x28);
+        assert_eq!(offset_of!(RegisterBlock, status), 0x30);
+        assert_eq!(offset_of!(RegisterBlock, channels), 0x100);
+    }
+
+    #[test]
+    fn offset_channel_registerblock() {
+        assert_eq!(offset_of!(ChannelRegisterBlock, enable), 0x0);
+        assert_eq!(offset_of!(ChannelRegisterBlock, pause), 0x4);
+        assert_eq!(offset_of!(ChannelRegisterBlock, start_addr), 0x08);
+        assert_eq!(offset_of!(ChannelRegisterBlock, config), 0xC);
+        assert_eq!(offset_of!(ChannelRegisterBlock, current_src_addr), 0x10);
+        assert_eq!(offset_of!(ChannelRegisterBlock, current_destination), 0x14);
+        assert_eq!(offset_of!(ChannelRegisterBlock, byte_counter_left), 0x18);
+        assert_eq!(offset_of!(ChannelRegisterBlock, parameter), 0x1C);
+        assert_eq!(offset_of!(ChannelRegisterBlock, mode), 0x28);
+        assert_eq!(offset_of!(ChannelRegisterBlock, former_desc_addr), 0x2C);
+        assert_eq!(offset_of!(ChannelRegisterBlock, package_num), 0x30);
+        assert_eq!(size_of::<ChannelRegisterBlock>(), 0x40);
+    }
+}

--- a/allwinner-hal/src/dma/register.rs
+++ b/allwinner-hal/src/dma/register.rs
@@ -27,28 +27,28 @@ pub struct RegisterBlock {
 #[repr(C)]
 pub struct ChannelRegisterBlock {
     /// DMAC Channel Enable Register.
-    pub enable: RW<u32>,
+    pub enable: ChannelEnableRegister,
     /// DMAC Channel Pause Register.
-    pub pause: RW<u32>,
+    pub pause: ChannelPauseRegister,
     /// DMAC Channel Start Address Register.
-    pub start_addr: RW<u32>,
+    pub start_addr: ChannelStartAddrRegister,
     /// DMAC Channel Configuration Register.
-    pub config: RO<u32>,
+    pub config: ChannelConfigRegister,
     /// DMAC Channel Current Source Register.
-    pub current_src_addr: RO<u32>,
+    pub current_src_addr: ChannelCurrentSrcAddrRegister,
     /// DMAC Channel Current Destination Register.
-    pub current_destination: RO<u32>,
+    pub current_destination: ChannelCurrentDestAddrRegister,
     /// DMAC Channel Byte Counter Left Register.
-    pub byte_counter_left: RO<u32>,
+    pub byte_counter_left: ChannelByteCounterLeftRegister,
     /// DMAC Channel Parameter Register.
-    pub parameter: RO<u32>,
+    pub parameter: ChannelParameterRegister,
     _reserved0: [u8; 0x8],
     /// DMAC Mode Register.
-    pub mode: RW<u32>,
+    pub mode: ChannelModeRegister,
     /// DMAC Former Descriptor Address Register.
-    pub former_desc_addr: RO<u32>,
+    pub former_desc_addr: ChannelFormerDescAddrRegister,
     /// DMAC Package Number Register.
-    pub package_num: RO<u32>,
+    pub package_num: ChannelPackageNumRegister,
     _reserved1: [u8; 0xC],
 }
 
@@ -56,22 +56,22 @@ impl ChannelEnableRegister {
     // DMA Channel Enable (Bit 0)
     pub const DMA_EN: u32 = 0x1 << 0;
 
-    /// Raw register value for DMA Channel Enable Register.
+    /// Check if DMA channel is enabled.
     #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
+    pub const fn is_dma_enabled(self) -> bool {
+        (self.0 & Self::DMA_EN) != 0
     }
 
-    /// Create from raw register value.
+    /// Enable DMA channel (set bit 0).
     #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
+    pub fn enable_dma(&mut self) {
+        self.0 |= Self::DMA_EN;
     }
 
-    /// Get the DMA channel enable bit.
+    /// Disable DMA channel (clear bit 0).
     #[inline]
-    pub const fn dma_en(self) -> u32 {
-        (self.0 & Self::DMA_EN) >> 0
+    pub fn disable_dma(&mut self) {
+        self.0 &= !Self::DMA_EN;
     }
 }
 
@@ -79,22 +79,22 @@ impl ChannelPauseRegister {
     // DMA Pause bit (Bit 0)
     pub const DMA_PAUSE: u32 = 0x1 << 0;
 
-    /// Raw register value for DMA Channel Pause Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
-
     /// Check if DMA transfer is paused.
     #[inline]
-    pub const fn dma_pause(self) -> u32 {
-        (self.0 & Self::DMA_PAUSE) >> 0
+    pub const fn if_dma_pause(self) -> bool {
+        (self.0 & Self::DMA_PAUSE) != 0
+    }
+
+    /// Pause DMA transfer (set bit 0).
+    #[inline]
+    pub fn pause_dma(&mut self) {
+        self.0 |= Self::DMA_PAUSE;
+    }
+
+    /// Resume DMA transfer (clear bit 0).
+    #[inline]
+    pub fn resume_dma(&mut self) {
+        self.0 &= !Self::DMA_PAUSE;
     }
 }
 
@@ -104,18 +104,6 @@ impl ChannelStartAddrRegister {
 
     // DMA descriptor address higher 2 bits (Bits [1:0])
     pub const DMA_DESC_HIGH_ADDR: u32 = 0x3 << 0;
-
-    /// Raw register value for DMA Channel Start Address Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
 
     /// Get lower 30 bits of the DMA descriptor address.
     #[inline]
@@ -140,20 +128,20 @@ impl ChannelConfigRegister {
     // BMODE_SEL (Bit 30)
     pub const BMODE_SEL: u32 = 0x1 << 30;
 
-    // DMA_DEST_DATA_WIDTH (Bits [29:27])
-    pub const DMA_DEST_DATA_WIDTH: u32 = 0x7 << 27;
-
-    // DMA_DEST_BLOCK_SIZE (Bits [26:25])
-    pub const DMA_DEST_BLOCK_SIZE: u32 = 0x3 << 25;
+    // DMA_DEST_DATA_WIDTH (Bits [26:25])
+    pub const DMA_DEST_DATA_WIDTH: u32 = 0x3 << 25;
 
     // DMA_ADDR_MODE (Bit 24)
     pub const DMA_ADDR_MODE: u32 = 0x1 << 24;
 
-    // DMA_DEST_DRQ_TYPE (Bits [23:16])
-    pub const DMA_DEST_DRQ_TYPE: u32 = 0xFF << 16;
+    // DMA_DEST_BLOCK_SIZE (Bits [23:22])
+    pub const DMA_DEST_BLOCK_SIZE: u32 = 0x3 << 22;
 
-    // DMA_SRC_DATA_WIDTH (Bits [15:11])
-    pub const DMA_SRC_DATA_WIDTH: u32 = 0xF << 11;
+    // DMA_DEST_DRQ_TYPE (Bits [21:16])
+    pub const DMA_DEST_DRQ_TYPE: u32 = 0x3F << 16;
+
+    // DMA_SRC_DATA_WIDTH (Bits [10:9])
+    pub const DMA_SRC_DATA_WIDTH: u32 = 0x3 << 9;
 
     // DMA_SRC_ADDR_MODE (Bit 8)
     pub const DMA_SRC_ADDR_MODE: u32 = 0x1 << 8;
@@ -164,18 +152,6 @@ impl ChannelConfigRegister {
     // DMA_SRC_DRQ_TYPE (Bits [5:0])
     pub const DMA_SRC_DRQ_TYPE: u32 = 0x3F << 0;
 
-    /// Raw register value for DMA Channel Configuration Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
-
     /// Get the BMODE_SEL bit.
     #[inline]
     pub const fn bmode_sel(self) -> u32 {
@@ -185,19 +161,19 @@ impl ChannelConfigRegister {
     /// Get the DMA_DEST_DATA_WIDTH bits.
     #[inline]
     pub const fn dma_dest_data_width(self) -> u32 {
-        (self.0 & Self::DMA_DEST_DATA_WIDTH) >> 27
-    }
-
-    /// Get the DMA_DEST_BLOCK_SIZE bits.
-    #[inline]
-    pub const fn dma_dest_block_size(self) -> u32 {
-        (self.0 & Self::DMA_DEST_BLOCK_SIZE) >> 25
+        (self.0 & Self::DMA_DEST_DATA_WIDTH) >> 25
     }
 
     /// Get the DMA_ADDR_MODE bit.
     #[inline]
     pub const fn dma_addr_mode(self) -> u32 {
         (self.0 & Self::DMA_ADDR_MODE) >> 24
+    }
+
+    /// Get the DMA_DEST_BLOCK_SIZE bits.
+    #[inline]
+    pub const fn dma_dest_block_size(self) -> u32 {
+        (self.0 & Self::DMA_DEST_BLOCK_SIZE) >> 22
     }
 
     /// Get the DMA_DEST_DRQ_TYPE bits.
@@ -209,7 +185,7 @@ impl ChannelConfigRegister {
     /// Get the DMA_SRC_DATA_WIDTH bits.
     #[inline]
     pub const fn dma_src_data_width(self) -> u32 {
-        (self.0 & Self::DMA_SRC_DATA_WIDTH) >> 11
+        (self.0 & Self::DMA_SRC_DATA_WIDTH) >> 9
     }
 
     /// Get the DMA_SRC_ADDR_MODE bit.
@@ -235,18 +211,6 @@ impl ChannelCurrentSrcAddrRegister {
     // DMA Current Source Address (Bits [31:0])
     pub const DMA_CUR_SRC: u32 = 0xFFFFFFFF;
 
-    /// Raw register value for DMA Channel Current Source Address Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
-
     /// Get the DMA current source address.
     #[inline]
     pub const fn dma_cur_src(self) -> u32 {
@@ -257,18 +221,6 @@ impl ChannelCurrentSrcAddrRegister {
 impl ChannelCurrentDestAddrRegister {
     // DMA Current Destination Address (Bits [31:0])
     pub const DMA_CUR_DEST: u32 = 0xFFFFFFFF;
-
-    /// Raw register value for DMA Channel Current Destination Address Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
 
     /// Get the DMA current destination address.
     #[inline]
@@ -281,18 +233,6 @@ impl ChannelByteCounterLeftRegister {
     // DMA Byte Counter Left (Bits [24:0])
     pub const DMA_BCNT_LEFT: u32 = 0xFFFFFF;
 
-    /// Raw register value for DMA Channel Byte Counter Left Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
-
     /// Get the DMA byte counter left value.
     #[inline]
     pub const fn dma_bcnt_left(self) -> u32 {
@@ -303,18 +243,6 @@ impl ChannelByteCounterLeftRegister {
 impl ChannelParameterRegister {
     // WAIT_CYC (Bits [7:0])
     pub const WAIT_CYC: u32 = 0xFF << 0;
-
-    /// Raw register value for DMA Channel Parameter Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
 
     /// Get the WAIT_CYC value.
     #[inline]
@@ -330,18 +258,6 @@ impl ChannelModeRegister {
     // DMA_SRC_MODE (Bit 2)
     pub const DMA_SRC_MODE: u32 = 0x1 << 2;
 
-    /// Raw register value for DMA Channel Mode Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
-
     /// Get the DMA destination communication mode.
     #[inline]
     pub const fn dma_dst_mode(self) -> u32 {
@@ -353,23 +269,21 @@ impl ChannelModeRegister {
     pub const fn dma_src_mode(self) -> u32 {
         (self.0 & Self::DMA_SRC_MODE) >> 2
     }
+
+    /// Set the DMA destination communication mode.
+    #[inline]
+    pub fn set_dma_dst_mode(&mut self, enable: bool) {
+        if enable {
+            self.0 |= Self::DMA_DST_MODE;
+        } else {
+            self.0 &= !Self::DMA_DST_MODE;
+        }
+    }
 }
 
 impl ChannelFormerDescAddrRegister {
     // DMA Former Descriptor Address (Bits [31:0])
     pub const DMA_FDESC_ADDR: u32 = 0xFFFFFFFF;
-
-    /// Raw register value for DMA Channel Former Descriptor Address Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
 
     /// Get the DMA former descriptor address.
     #[inline]
@@ -381,18 +295,6 @@ impl ChannelFormerDescAddrRegister {
 impl ChannelPackageNumRegister {
     // DMA Package Number (Bits [31:0])
     pub const DMA_PKG_NUM: u32 = 0xFFFFFFFF;
-
-    /// Raw register value for DMA Channel Package Number Register.
-    #[inline]
-    pub const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Create from raw register value.
-    #[inline]
-    pub const fn from_raw(value: u32) -> Self {
-        Self(value)
-    }
 
     /// Get the DMA package number.
     #[inline]


### PR DESCRIPTION
Purpose:
Update DMA register definitions and provide bit-level control for channel operations.

Key Changes:
1.Added DMA channel register definitions in ChannelRegisterBlock.
2.Implemented bit-level setting and retrieval functions for DMA registers.
3.Added unit tests for register offsets and sizes.

Code Changes:
1.Defined new DMA channel registers in RegisterBlock and ChannelRegisterBlock.
2.Implemented bit-level functions for controlling registers.